### PR TITLE
Delete jakarta.servlet.jsp.jstl from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,6 @@
             <version>5.0.0</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.web</groupId>
-            <artifactId>jakarta.servlet.jsp.jstl</artifactId>
-            <version>2.0.0</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
We don't need JSTL yet.